### PR TITLE
Fixes RFC 5280 incompatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ package_dir =
 packages = find:
 install_requires =
     pycurl>=7.45.0
-    cryptography>=38.0.0
+    cryptography==43.0.3
     defusedxml
 
 [options.entry_points]


### PR DESCRIPTION
Forces the last working version to be used

Forces the last working version of cryptography to be used, later versions are incompatible with the 3DS certificates.


- Pull request re-created to prevent further work being automatically appended 

#3 