### PR TITLE
Strip trailing bytes from key in _configure_cli_cert_and_key, as OpenSSL 3 is stricter and rejects it unless sliced to DER length

### DIFF
--- a/src/cleaninty/ctr/constants.py
+++ b/src/cleaninty/ctr/constants.py
@@ -577,12 +577,12 @@ def _configure_cli_cert_and_key(enc_cert: bytes, enc_key: bytes):
 			
 			# strip trailing bytes: decrypted key blob contains DER key + struct padding.
             # OpenSSL 1.1 tolerated this, OpenSSL 3 rejects it unless sliced to DER length.
-			if _key[:2] == b"\x30\x82":
-				key_len = unpack(">2xH", _key[:4])[0]
-				_key = _key[:key_len + 4]
-			
-			key = serialization.load_der_private_key(_key, password=None)
+			if _key[:2] != b"\x30\x82":
+				continue
 
+			size = unpack(">2xH", _key[:4])[0]
+			key = serialization.load_der_private_key(_key[:size+4], password=None)
+			
 			k1 = cert.public_key()
 			k2 = key.public_key()
 

--- a/src/cleaninty/ctr/constants.py
+++ b/src/cleaninty/ctr/constants.py
@@ -574,7 +574,13 @@ def _configure_cli_cert_and_key(enc_cert: bytes, enc_key: bytes):
 				default_backend()
 			).decryptor()
 			_key = decryptor.update(enc_key[16:]) + decryptor.finalize()
-
+			
+			# strip trailing bytes: decrypted key blob contains DER key + struct padding.
+            # OpenSSL 1.1 tolerated this, OpenSSL 3 rejects it unless sliced to DER length.
+			if _key[:2] == b"\x30\x82":
+				key_len = unpack(">2xH", _key[:4])[0]
+				_key = _key[:key_len + 4]
+			
 			key = serialization.load_der_private_key(_key, password=None)
 
 			k1 = cert.public_key()


### PR DESCRIPTION
This was a day of investigation with me and luigoalma, until eventually I took a very deep look at the code.

OpenSSL 1.1.x (which Ubuntu, Debian, WSL use) silently ignored the trailing padding, so the key loaded successfully.

OpenSSL 3.x (now on many distros) strictly validates DER and rejects the trailing data with:
`ASN.1 parsing error: unexpected tag`
This preserves the existing behavior, but allows it to work with OpenSSL 3.x.